### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/components/FormSub.tsx
+++ b/src/components/FormSub.tsx
@@ -55,7 +55,7 @@ const SubForm = () => {
   };
 
   const redirectToHome = () => {
-    const isGitHubPages = window.location.hostname.includes("github.io");
+    const isGitHubPages = window.location.hostname.endsWith(".github.io");
     if (isGitHubPages) {
       const pathSegments = window.location.pathname
         .split("/")


### PR DESCRIPTION
Potential fix for [https://github.com/ecastthapathali/ecastthapathali.github.io/security/code-scanning/2](https://github.com/ecastthapathali/ecastthapathali.github.io/security/code-scanning/2)

To properly check if the current site is a GitHub Pages domain, we need to ensure that the `window.location.hostname` has a value that ends with `.github.io`, and that it matches the expected domain format. This can be done by:  
- Replacing `.includes("github.io")` with `.endsWith(".github.io")`.  
- Optionally, you could also check that the host consists of a non-empty subdomain before `.github.io` (not required by the original code, but implies a single-level subdomain as used by GitHub Pages with user and organization pages).

The change is limited to a single line in the `redirectToHome` function, replacing line 58.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
