### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,4 +1,6 @@
 name: Deploy to GitHub Pages
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ecastthapathali/ecastthapathali.github.io/security/code-scanning/1](https://github.com/ecastthapathali/ecastthapathali.github.io/security/code-scanning/1)

The best way to fix the issue is to add an explicit `permissions` block to the workflow file. This `permissions` key should be placed at the top level (for all jobs), or at least within the `build` job, and specify the minimal set of permissions required for the workflow to function. In the context of deploying to GitHub Pages using `peaceiris/actions-gh-pages`, the workflow needs to be able to write to the `gh-pages` branch, so `contents: write` is required. Other permissions (such as for pull-requests) are not necessary unless the workflow interacts with PRs, which it does not. Therefore, add at the top level (recommended, unless only a subset of jobs require access) a block as follows:

```yaml
permissions:
  contents: write
```

Edit the file `.github/workflows/static.yml` by inserting the above under the workflow `name` and before `on:` (ideally on line 2). No new packages, external methods, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
